### PR TITLE
remove redundant call, add filter to GA API call, switch to date_i18n()

### DIFF
--- a/toplytics/class-toplytics-auth.php
+++ b/toplytics/class-toplytics-auth.php
@@ -65,7 +65,7 @@ class Toplytics_Auth {
 		$url .= sizeof( $dimensions ) > 0 ? ( '&dimensions=' . join( array_reverse( $dimensions ), ',' ) ) : '';
 		$url .= sizeof( $metrics ) > 0 ? ( '&metrics=' . join( $metrics, ',' ) ) : '';
 		$url .= sizeof( $sort ) > 0 ? '&sort=' . join( $sort, ',' ) : '';
-		$url .= '&start-date=' . $start_date . '&end-date=' . date( 'Y-m-d' ) . '&max-results=' . TOPLYTICS_GET_MAX_RESULTS;
+		$url .= '&start-date=' . $start_date . '&end-date=' . date_i18n( 'Y-m-d' ) . '&max-results=' . TOPLYTICS_GET_MAX_RESULTS;
 
 		return apply_filters( 'toplytics_ga_api_url', $url );
 	}


### PR DESCRIPTION
1) I noticed that the get_transient() call is not needed here. $results gets overwritten right after.
2) I need a filter added in to make modifications to the GA API in my own plugin. This wouldn't change any behavior, so, I hope that we can add this in. Thank you!
3) switch to date_i18n() function to account for time zone set in WP
