### PR TITLE
Changed the inner id to be more specific

### DIFF
--- a/toplytics/inc/class-toplytics-wp-widget.php
+++ b/toplytics/inc/class-toplytics-wp-widget.php
@@ -77,7 +77,7 @@ class Toplytics_WP_Widget extends WP_Widget {
 				echo $before_title . $title . $after_title;
 			}
 			$toplytics_args = array(
-				'widget_id'    => $widget_id,
+				'widget_id'    => $widget_id . '-placeholder',
 				'period'       => $period,
 				'numberposts'  => $numberposts,
 				'showviews'    => $showviews,
@@ -86,7 +86,7 @@ class Toplytics_WP_Widget extends WP_Widget {
 				'after_title'  => $after_title,
 			);
 			$this->realtime_js_script( $toplytics_args );
-			echo "<div id='$widget_id'></div>";
+			echo "<div id='$widget_id-placeholder'></div>";
 			include $template_filename;
 			echo $after_widget;
 		}


### PR DESCRIPTION
Themes can add a wrapper to the widget with the widget id and thus confusing the js populating script.