### PR TITLE
Add Support for Google Analytics v4

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -49,13 +49,13 @@ This WordPress plugin can be found at [wordpress.org/plugins/toplytics/](https:/
 
 Alternatively, go into your WordPress dashboard and click on *Plugins -> Add Plugin* and search for Toplytics. Then click on *Install*, then on *Activate Now*.
 
-We offer two possibilities to use Toplytics: through **Public Authorization** or the **Private Authorization**, for more configuration details check [Toplytics installation](https://www.presslabs.com/code/toplytics/installation/).
+We offer two possibilities to use Toplytics: through **Quick Connect** or the **Manual Connect**, for more configuration details check [Toplytics installation](https://www.presslabs.com/code/toplytics/installation/).
 
-The **Public Authorization** method is using the Presslabs public API key to authenticate you to the Google Analytics API, and you don't have to set up your own API keys. To use this method, simply press the **Log in with your Google Account via Presslabs.org** button and you will be redirected to the Google Authorization screen where you will be asked for read access to your analytics profiles.
+The **Quick Connect** method is using the Presslabs public API key to authenticate you to the Google Analytics API, and you don't have to set up your own API keys. To use this method, simply press the **Log in with your Google Account via Presslabs.org** button and you will be redirected to the Google Authorization screen where you will be asked for read access to your analytics profiles.
 
 Then you need to select your profile and you are all set.
 
-The private authorization is the recommended way in using Toplytics, as it offers you complete control over the connection by using your very own API keys and application for granting access.
+The manual connect is the recommended way in using Toplytics, as it offers you complete control over the connection by using your very own API keys and application for granting access.
 
 You need to enter your Client ID and Client Secret from your Google Analytics account. The next steps will guide you in configuring your Google Analytics account to Toplytics. Keep in mind that you will need the **Redirect URL** mentioned in this page further in configuring Toplytics.
 
@@ -70,14 +70,14 @@ In this step please register a new client application with Google. To register a
 
 After you set up your product name, you can create your credentials. Go back to the **Dashboard** section, click on the arrow of the button **Create credentials** and choose the **OAuth Client ID** option.
 
-When asked to choose your application type choose the **Web application** option. You will be asked to introduce the **Javascript Origins** and **Redirects URI's**. As **Authorized JavaScipt Origins** introduce your domain name, and as **Authorized redirect URI** you need to introduce the Redirect URL from `Settings -> Toplytics -> Private Authorization`.
+When asked to choose your application type choose the **Web application** option. You will be asked to introduce the **Javascript Origins** and **Redirects URI's**. As **Authorized JavaScipt Origins** introduce your domain name, and as **Authorized redirect URI** you need to introduce the Redirect URL from `Settings -> Toplytics -> Manual Connect`.
 
 Your newly created credentials will appear on the **Credentials** page and the **Client ID** and **Client secret** you need to authorize the **Private Authentification** will appear in a pop up. You can also see them by pressing the **Edit OAuth Client** button from the Credentials section.
 
 = Configuration step 2 =
 In this step you will need to authorize requests.
 
-1. Copy the Client ID and the Client Secret keys from the **Credentials section**, then go back to `Settings -> Toplytics -> Private Authorization` to paste these credentials. By using these keys the client application will avoid sharing the username and/or password with any other Toplytics users.
+1. Copy the Client ID and the Client Secret keys from the **Credentials section**, then go back to `Settings -> Toplytics -> Manual Connect` to paste these credentials. By using these keys the client application will avoid sharing the username and/or password with any other Toplytics users.
 
 2. Click the **Private Authorize** button and after logging in you need to agree that the newly created app will access your Analytics data and you are all set.
 

--- a/src/components/Activator.php
+++ b/src/components/Activator.php
@@ -105,9 +105,9 @@ class Activator
 
         $options = [
             'toplytics_results_ranges' => [
-                'month' => date_i18n('Y-m-d', strtotime('-29 days')),
-                'week'  => date_i18n('Y-m-d', strtotime('-6 days')),
-                'today' => date_i18n('Y-m-d', strtotime('today')),
+                'month' => '30daysAgo',
+                'week'  => '7daysAgo',
+                'today' => 'yesterday',
                 'realtime' => 0,
             ],
             'toplytics_private_auth_config' => false,

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1231,12 +1231,13 @@ class Backend
         }
 
         // TODO: Make these settings configurable.
-        $results_ranges = [
-            'month' => date_i18n('Y-m-d', strtotime('-29 days')),
-            'week'  => date_i18n('Y-m-d', strtotime('-6 days')),
-            // 'today' => date_i18n('Y-m-d', strtotime('today')),
-            // 'realtime' => 0,
-        ];
+        // Fetch results ranges from option. Create the option, if it does not exist.
+        $results_ranges = get_option( 'toplytics_results_ranges', false );
+        if ( ! $results_ranges ) {
+            Activator::addDefaultOptions();
+            // Fetch the option, once again; it is now initialized.
+            $results_ranges = get_option( 'toplytics_results_ranges' );
+        }
 
         $result = [];
 

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1251,7 +1251,7 @@ class Backend
                 'end_date' => date_i18n('Y-m-d', time()),
             ]);
 
-            $request = new Google_Service_AnalyticsData_RunReportRequest([
+            $request = new Google_Service_AnalyticsData_RunReportRequest( apply_filters('toplytics_analytics_params_v4', [
                 'property' => $propertyId,
                 'date_ranges' => [$dateRange],
                 'dimensions' => [$dimension],
@@ -1266,7 +1266,7 @@ class Backend
                     ]),
                 ]),
                 'order_bys' => $orderBys,
-            ]);
+            ], $when, $start_date));
             
             $response = $this->service->properties->runReport($propertyId, $request);
             

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -152,7 +152,11 @@ class Backend
         }
 
         // we run our updates
-        return $this->runDBUpdates($db_version);
+        $updates = $this->runDBUpdates($db_version);
+
+        update_option('toplytics_db_version', $this->version);
+
+        return $updates;
     }
 
     /**

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -143,14 +143,16 @@ class Backend
 
         // if db_version is empty, set it to current version
         if (empty($db_version)) {
-            update_option('toplytics_db_version', TOPLYTICS_DB_VERSION);
+            update_option('toplytics_db_version', $this->version);
         }
 
-        if ($db_version == TOPLYTICS_DB_VERSION) {
+        // same version, no updates required
+        if (version_compare($db_version, $this->version, '==')) {
             return 0;
         }
 
-        return $this->runDBUpdates((int)$db_version);
+        // we run our updates
+        return $this->runDBUpdates($db_version);
     }
 
     /**
@@ -164,15 +166,18 @@ class Backend
 
         $updates = 0;
 
-        // TODO: Rethink this logic.
+        $alreadyApplied = get_option('toplytics_db_updates_applied', []);
+
         switch ($version) {
-            case 1:
+            case '4.1.0':
+                if (in_array('4.1.0', $alreadyApplied)) continue;
                 update_option('toplytics_results_ranges', [
                     'month' => '30daysAgo',
                     'week'  => '7daysAgo',
                     'today' => 'yesterday',
                     'realtime' => 0,
                 ]);
+                update_option('toplytics_db_updates_applied', array_merge($alreadyApplied, ['4.1.0']));
                 $updates++;
         }
 

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -170,7 +170,7 @@ class Backend
 
         switch ($version) {
             case '4.1.0':
-                if (in_array('4.1.0', $alreadyApplied)) continue;
+                if (in_array('4.1.0', $alreadyApplied)) break;
                 update_option('toplytics_results_ranges', [
                     'month' => '30daysAgo',
                     'week'  => '7daysAgo',

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1710,7 +1710,7 @@ class Backend
 
     /**
      * Decoding the actual JSON config file we read from
-     * the presslabs.org site for public authorization.
+     * the presslabs.org site for quick connect.
      *
      * @since 4.0.0
      * @param string $config The JSON content to be decoded
@@ -1733,7 +1733,7 @@ class Backend
 
     /**
      * This is the place where we arrive after pressing the
-     * Public Authorization button. Here we redirect the user
+     * Quick Connect button. Here we redirect the user
      * to the Public Google page.
      *
      * @return Redirect Redirect to Google Authorization

--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -143,6 +143,7 @@ class Backend
 
         // if db_version is empty, set it to current version
         if (empty($db_version)) {
+            $db_version = '1.0.0';
             update_option('toplytics_db_version', $this->version);
         }
 
@@ -152,7 +153,7 @@ class Backend
         }
 
         // we run our updates
-        $updates = $this->runDBUpdates($db_version);
+        $updates = $this->runDBUpdates($this->version);
 
         update_option('toplytics_db_version', $this->version);
 
@@ -175,13 +176,16 @@ class Backend
         switch ($version) {
             case '4.1.0':
                 if (in_array('4.1.0', $alreadyApplied)) break;
+
                 update_option('toplytics_results_ranges', [
                     'month' => '30daysAgo',
                     'week'  => '7daysAgo',
                     'today' => 'yesterday',
                     'realtime' => 0,
                 ]);
+
                 update_option('toplytics_db_updates_applied', array_merge($alreadyApplied, ['4.1.0']));
+                
                 $updates++;
         }
 

--- a/src/components/Engine.php
+++ b/src/components/Engine.php
@@ -139,6 +139,8 @@ class Engine
         $this->loader->addAction('admin_init', $plugin_admin, 'privateAuthorization');
         $this->loader->addAction('admin_init', $plugin_admin, 'checkAuthorization');
         $this->loader->addAction('admin_init', $plugin_admin, 'serviceDisconnect');
+        $this->loader->addAction('admin_init', $plugin_admin, 'useGA4');
+        $this->loader->addAction('admin_init', $plugin_admin, 'useUA');
         $this->loader->addAction('admin_init', $plugin_admin, 'profileSelect');
         $this->loader->addAction('admin_init', $plugin_admin, 'switchProfile');
         $this->loader->addAction('admin_init', $plugin_admin, 'initSettings');

--- a/src/components/Frontend.php
+++ b/src/components/Frontend.php
@@ -282,10 +282,11 @@ class Frontend
     public function restApiInit()
     {
         if ($this->checkSetting('enable_rest_endpoint')) {
-            register_rest_route('toplytics/', 'results', array(
+            register_rest_route('toplytics', '/results/', array(
         
-            'methods' => 'GET',
+            'methods' => \WP_REST_Server::READABLE,
             'callback' => [$this, 'toplyticsMasterApiEndpoint'],
+            'permission_callback' => '__return_true',
             ));
         }
     }

--- a/src/components/Widget.php
+++ b/src/components/Widget.php
@@ -82,8 +82,17 @@ class Widget extends \WP_Widget
      */
     public function widget($args, $instance)
     {
+
         ob_start();
 
+        $title = '';
+        $period = 'week';
+        $numberposts = 20;
+        $showviews = 0;
+        $loadViaJS = 0;
+        $category = 0;
+        $fallback_not_enough_ga_posts = 'recent';
+    
         extract($args);
         extract($instance);
 
@@ -209,8 +218,8 @@ class Widget extends \WP_Widget
         $instance['loadViaJS'] = isset($new_instance['loadViaJS']) ? 1 : 0;
 
         // If the category is set, add hook for refreshing the Toplytics posts for the categories.
-        if ( $instance['category'] != $old_instance['category'] ) {
-            add_action( 'update_option_widget_toplytics-widget', array( $this, 'update_additional_posts_data' ), 10, 3 );
+        if (isset($instance['category']) && isset($old_instance['category']) && $instance['category'] != $old_instance['category']) {
+            add_action('update_option_widget_toplytics-widget', array($this, 'update_additional_posts_data'), 10, 3);
         }
         
         return $instance;

--- a/src/components/Widget.php
+++ b/src/components/Widget.php
@@ -156,6 +156,10 @@ class Widget extends \WP_Widget
         }
 
         if ($loadViaJS && ($this->frontend->checkSetting('enable_json') || $this->frontend->checkSetting('enable_rest_endpoint'))) {
+
+            // make sure id is defined
+            $widget_id = isset($widget_id) ? $widget_id : 'widget-' . uniqid();
+
             $toplytics_args = array(
                 'widget_id' => $widget_id . '-inner',
                 'period' => $period,

--- a/src/composer.json
+++ b/src/composer.json
@@ -15,15 +15,17 @@
         }
     ],
     "require": {
-        "php": "~7.0",
-        "google/apiclient": "^2.10"
+        "php": "^8.1",
+        "google/apiclient": "^2.12",
+        "google/apiclient-services": "^0.311.0"
     },
     "scripts": {
         "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
     },
     "extra": {
         "google/apiclient-services": [
-            "Analytics"
+            "Analytics",
+            "AnalyticsData"
         ]
     },
     "autoload": {

--- a/src/composer.json
+++ b/src/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^7.4",
         "google/apiclient": "^2.12",
         "google/apiclient-services": "^0.311.0"
     },

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,34 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bb48cfc408710b4be0eb405071842c4",
+    "content-hash": "ac0bdeae8339a0ec9b0f3d79b2cadd75",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.2.0",
+            "version": "v6.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d28e6df83830252650da4623c78aaaf98fb385f3"
+                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d28e6df83830252650da4623c78aaaf98fb385f3",
-                "reference": "d28e6df83830252650da4623c78aaaf98fb385f3",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1||^8.0"
+                "php": "^7.4||^8.0"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^6.5||^7.4",
-                "phpspec/prophecy-phpunit": "^1.1",
-                "phpunit/phpunit": "^7.5||^9.5",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
                 "psr/cache": "^1.0||^2.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
             },
             "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
                 "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
             },
             "type": "library",
@@ -64,44 +65,43 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.2.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
             },
-            "time": "2022-05-13T20:54:50+00:00"
+            "time": "2023-07-14T18:33:00+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.12.6",
+            "version": "v2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "f92aa126903a9e2da5bd41a280d9633cb249e79e"
+                "reference": "49787fa30b8d8313146a61efbf77ed1fede723c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/f92aa126903a9e2da5bd41a280d9633cb249e79e",
-                "reference": "f92aa126903a9e2da5bd41a280d9633cb249e79e",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/49787fa30b8d8313146a61efbf77ed1fede723c2",
+                "reference": "49787fa30b8d8313146a61efbf77ed1fede723c2",
                 "shasum": ""
             },
             "require": {
-                "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0||~6.0",
+                "firebase/php-jwt": "~6.0",
                 "google/apiclient-services": "~0.200",
-                "google/auth": "^1.10",
-                "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",
+                "google/auth": "^1.28",
+                "guzzlehttp/guzzle": "~6.5||~7.0",
                 "guzzlehttp/psr7": "^1.8.4||^2.2.1",
-                "monolog/monolog": "^1.17||^2.0||^3.0",
-                "php": "^5.6|^7.0|^8.0",
-                "phpseclib/phpseclib": "~2.0||^3.0.2"
+                "monolog/monolog": "^2.9||^3.0",
+                "php": "^7.4|^8.0",
+                "phpseclib/phpseclib": "^3.0.2"
             },
             "require-dev": {
-                "cache/filesystem-adapter": "^0.3.2|^1.1",
+                "cache/filesystem-adapter": "^1.1",
                 "composer/composer": "^1.10.22",
                 "phpcompatibility/php-compatibility": "^9.2",
-                "phpspec/prophecy-phpunit": "^1.1||^2.0",
-                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.0",
                 "symfony/css-selector": "~2.1",
-                "symfony/dom-crawler": "~2.1",
-                "yoast/phpunit-polyfills": "^1.0"
+                "symfony/dom-crawler": "~2.1"
             },
             "suggest": {
                 "cache/filesystem-adapter": "For caching certs and tokens (using Google\\Client::setCache)"
@@ -134,26 +134,26 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.12.6"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.15.0"
             },
-            "time": "2022-06-06T20:00:19+00:00"
+            "time": "2023-05-18T13:51:33+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.252.0",
+            "version": "v0.311.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "9941c959f6a1f781e49019b78f453d54554dff73"
+                "reference": "b29fb9e55b1616c056e349d904ad5e6ff39b5bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/9941c959f6a1f781e49019b78f453d54554dff73",
-                "reference": "9941c959f6a1f781e49019b78f453d54554dff73",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/b29fb9e55b1616c056e349d904ad5e6ff39b5bed",
+                "reference": "b29fb9e55b1616c056e349d904ad5e6ff39b5bed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.4||^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7||^8.5.13"
@@ -178,38 +178,38 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.252.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.311.0"
             },
-            "time": "2022-06-06T01:20:11+00:00"
+            "time": "2023-07-29T01:00:21+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.21.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "73392bad2eb6852eea9084b6bbdec752515cb849"
+                "reference": "07f7f6305f1b7df32b2acf6e101c1225c839c7ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/73392bad2eb6852eea9084b6bbdec752515cb849",
-                "reference": "73392bad2eb6852eea9084b6bbdec752515cb849",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/07f7f6305f1b7df32b2acf6e101c1225c839c7ac",
+                "reference": "07f7f6305f1b7df32b2acf6e101c1225c839c7ac",
                 "shasum": ""
             },
             "require": {
-                "firebase/php-jwt": "^5.5||^6.0",
+                "firebase/php-jwt": "^6.0",
                 "guzzlehttp/guzzle": "^6.2.1|^7.0",
-                "guzzlehttp/psr7": "^1.7|^2.0",
-                "php": "^7.1||^8.0",
-                "psr/cache": "^1.0|^2.0|^3.0",
-                "psr/http-message": "^1.0"
+                "guzzlehttp/psr7": "^2.4.5",
+                "php": "^7.4||^8.0",
+                "psr/cache": "^1.0||^2.0||^3.0",
+                "psr/http-message": "^1.1||^2.0"
             },
             "require-dev": {
-                "guzzlehttp/promises": "0.1.1|^1.3",
-                "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
-                "phpseclib/phpseclib": "^2.0.31",
-                "phpspec/prophecy-phpunit": "^1.1",
-                "phpunit/phpunit": "^7.5||^8.5",
+                "guzzlehttp/promises": "^1.3",
+                "kelvinmo/simplejwt": "0.7.0",
+                "phpseclib/phpseclib": "^3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0.0",
                 "sebastian/comparator": ">=1.2.3",
                 "squizlabs/php_codesniffer": "^3.5"
             },
@@ -236,28 +236,28 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.21.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.28.0"
             },
-            "time": "2022-04-13T20:35:52+00:00"
+            "time": "2023-05-11T21:58:18+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.4",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8"
+                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
-                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -266,10 +266,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "^3.0",
-                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -279,8 +280,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "7.4-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
@@ -346,7 +348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.4"
+                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
             },
             "funding": [
                 {
@@ -362,38 +364,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T21:39:15+00:00"
+            "time": "2023-05-21T14:04:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
+                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
+                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -430,7 +431,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.0.0"
             },
             "funding": [
                 {
@@ -446,7 +447,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-22T20:56:57+00:00"
+            "time": "2023-05-21T13:50:22+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -566,43 +567,41 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.7.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524"
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5579edf28aee1190a798bfa5be8bc16c563bd524",
-                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                "psr/log-implementation": "3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "aws/aws-sdk-php": "^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2",
-                "guzzlehttp/guzzle": "^7.4",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "php-console/php-console": "^3.1.3",
-                "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5.14",
-                "predis/predis": "^1.1",
-                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
                 "ruflin/elastica": "^7",
-                "swiftmailer/swiftmailer": "^5.3|^6.0",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -619,14 +618,13 @@
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                 "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
                 "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -654,7 +652,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.7.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
             },
             "funding": [
                 {
@@ -666,7 +664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T08:59:12+00:00"
+            "time": "2023-06-21T08:46:11+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -787,16 +785,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.19",
+            "version": "3.0.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "cc181005cf548bfd8a4896383bb825d859259f95"
+                "reference": "4580645d3fc05c189024eb3b834c6c1e4f0f30a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cc181005cf548bfd8a4896383bb825d859259f95",
-                "reference": "cc181005cf548bfd8a4896383bb825d859259f95",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/4580645d3fc05c189024eb3b834c6c1e4f0f30a1",
+                "reference": "4580645d3fc05c189024eb3b834c6c1e4f0f30a1",
                 "shasum": ""
             },
             "require": {
@@ -877,7 +875,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.19"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.21"
             },
             "funding": [
                 {
@@ -893,24 +891,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-05T17:13:09+00:00"
+            "time": "2023-07-09T15:24:48+00:00"
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -930,7 +928,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -940,27 +938,27 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -980,7 +978,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -992,9 +990,9 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-04-10T20:12:12+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1053,16 +1051,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.1",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
                 "shasum": ""
             },
             "require": {
@@ -1071,7 +1069,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1086,7 +1084,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -1100,36 +1098,36 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/1.1"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2023-04-04T09:50:52+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1150,9 +1148,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -1200,25 +1198,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1247,7 +1245,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -1263,7 +1261,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         }
     ],
     "packages-dev": [],
@@ -1273,7 +1271,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.0"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac0bdeae8339a0ec9b0f3d79b2cadd75",
+    "content-hash": "d9b80235bd7c3c6d8aea770842cc07b8",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -71,16 +71,16 @@
         },
         {
             "name": "google/apiclient",
-            "version": "v2.15.0",
+            "version": "v2.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "49787fa30b8d8313146a61efbf77ed1fede723c2"
+                "reference": "7a95ed29e4b6c6859d2d22300c5455a92e2622ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/49787fa30b8d8313146a61efbf77ed1fede723c2",
-                "reference": "49787fa30b8d8313146a61efbf77ed1fede723c2",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/7a95ed29e4b6c6859d2d22300c5455a92e2622ad",
+                "reference": "7a95ed29e4b6c6859d2d22300c5455a92e2622ad",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "guzzlehttp/psr7": "^1.8.4||^2.2.1",
                 "monolog/monolog": "^2.9||^3.0",
                 "php": "^7.4|^8.0",
-                "phpseclib/phpseclib": "^3.0.2"
+                "phpseclib/phpseclib": "^3.0.19"
             },
             "require-dev": {
                 "cache/filesystem-adapter": "^1.1",
@@ -134,22 +134,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.15.0"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.15.1"
             },
-            "time": "2023-05-18T13:51:33+00:00"
+            "time": "2023-09-13T21:46:39+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.311.0",
+            "version": "v0.311.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "b29fb9e55b1616c056e349d904ad5e6ff39b5bed"
+                "reference": "e8816f6708fac9d78ab59ef27a61a08d0af84d1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/b29fb9e55b1616c056e349d904ad5e6ff39b5bed",
-                "reference": "b29fb9e55b1616c056e349d904ad5e6ff39b5bed",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/e8816f6708fac9d78ab59ef27a61a08d0af84d1e",
+                "reference": "e8816f6708fac9d78ab59ef27a61a08d0af84d1e",
                 "shasum": ""
             },
             "require": {
@@ -178,22 +178,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.311.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.311.1"
             },
-            "time": "2023-07-29T01:00:21+00:00"
+            "time": "2023-08-06T00:56:12+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "07f7f6305f1b7df32b2acf6e101c1225c839c7ac"
+                "reference": "6028b072aa444d7edecbed603431322026704627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/07f7f6305f1b7df32b2acf6e101c1225c839c7ac",
-                "reference": "07f7f6305f1b7df32b2acf6e101c1225c839c7ac",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/6028b072aa444d7edecbed603431322026704627",
+                "reference": "6028b072aa444d7edecbed603431322026704627",
                 "shasum": ""
             },
             "require": {
@@ -205,8 +205,8 @@
                 "psr/http-message": "^1.1||^2.0"
             },
             "require-dev": {
-                "guzzlehttp/promises": "^1.3",
-                "kelvinmo/simplejwt": "0.7.0",
+                "guzzlehttp/promises": "^2.0",
+                "kelvinmo/simplejwt": "0.7.1",
                 "phpseclib/phpseclib": "^3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.0.0",
@@ -236,28 +236,28 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.28.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.30.0"
             },
-            "time": "2023-05-11T21:58:18+00:00"
+            "time": "2023-09-07T19:13:44+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -348,7 +348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
             },
             "funding": [
                 {
@@ -364,20 +364,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T14:04:53+00:00"
+            "time": "2023-08-27T10:20:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
                 "shasum": ""
             },
             "require": {
@@ -431,7 +431,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.0"
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
             },
             "funding": [
                 {
@@ -447,20 +447,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T13:50:22+00:00"
+            "time": "2023-08-03T15:11:55+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
                 "shasum": ""
             },
             "require": {
@@ -547,7 +547,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
             },
             "funding": [
                 {
@@ -563,45 +563,46 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-08-27T10:13:57+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.4.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
-                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "psr/log": "^2.0 || ^3.0"
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "3.0.0"
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^3.0",
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2.0",
-                "guzzlehttp/guzzle": "^7.4.5",
+                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
+                "guzzlehttp/guzzle": "^7.4",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpstan/phpstan": "^1.9",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.4",
-                "phpunit/phpunit": "^10.1",
-                "predis/predis": "^1.1 || ^2",
+                "phpspec/prophecy": "^1.15",
+                "phpstan/phpstan": "^0.12.91",
+                "phpunit/phpunit": "^8.5.14",
+                "predis/predis": "^1.1 || ^2.0",
+                "rollbar/rollbar": "^1.3 || ^2 || ^3",
                 "ruflin/elastica": "^7",
+                "swiftmailer/swiftmailer": "^5.3|^6.0",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -624,7 +625,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -652,7 +653,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.1"
             },
             "funding": [
                 {
@@ -664,7 +665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-21T08:46:11+00:00"
+            "time": "2023-02-06T13:44:46+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -785,16 +786,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.21",
+            "version": "3.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "4580645d3fc05c189024eb3b834c6c1e4f0f30a1"
+                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/4580645d3fc05c189024eb3b834c6c1e4f0f30a1",
-                "reference": "4580645d3fc05c189024eb3b834c6c1e4f0f30a1",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/866cc78fbd82462ffd880e3f65692afe928bed50",
+                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50",
                 "shasum": ""
             },
             "require": {
@@ -875,7 +876,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.21"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.23"
             },
             "funding": [
                 {
@@ -891,24 +892,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-09T15:24:48+00:00"
+            "time": "2023-09-18T17:22:01+00:00"
         },
         {
             "name": "psr/cache",
-            "version": "3.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
@@ -928,7 +929,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -938,9 +939,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+                "source": "https://github.com/php-fig/cache/tree/master"
             },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/http-client",
@@ -1104,30 +1105,30 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1148,9 +1149,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -1198,25 +1199,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1245,7 +1246,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -1261,7 +1262,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         }
     ],
     "packages-dev": [],
@@ -1271,8 +1272,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/languages/toplytics-ro_RO.po
+++ b/src/languages/toplytics-ro_RO.po
@@ -444,8 +444,8 @@ msgstr "Autorizare Cont Google"
 
 #: resources/views/backend/authorization.blade.php:20
 #: resources/views/backend/tabs/publicConnect.blade.php:12
-msgid "Public Authorization"
-msgstr "Autorizare Publică"
+msgid "Quick Connect"
+msgstr "Conectare rapidă"
 
 #: resources/views/backend/authorization.blade.php:26
 msgid "Private Authorization (Advanced)"

--- a/src/resources/views/backend/authorization.php
+++ b/src/resources/views/backend/authorization.php
@@ -28,14 +28,14 @@ global $toplytics_engine;
         <a class="nav-tab <?php echo $nav_tab_active; ?>"
             href="<?php echo admin_url( TOPLYTICS_SUBMENU_PAGE . '?page=' . TOPLYTICS_DOMAIN . '&amp;tab=' . 'public' ); ?>"
             title="<?php esc_attr_e( 'This is for the everyday user and small websites.', TOPLYTICS_DOMAIN ); ?>">
-            <?php _e( 'Public Authorization', TOPLYTICS_DOMAIN ); ?>
+            <?php _e( 'Quick Connect', TOPLYTICS_DOMAIN ); ?>
         </a>
 
         <?php $nav_tab_active = ( isset( $_GET['tab'] )  && ( $_GET['tab'] == 'private' ) ) ? 'nav-tab-active' : ''; ?>
         <a class="nav-tab <?php echo $nav_tab_active; ?>"
             href="<?php echo admin_url( TOPLYTICS_SUBMENU_PAGE . '?page=' . TOPLYTICS_DOMAIN . '&amp;tab=' . 'private' ); ?>"
             title="<?php esc_attr_e( 'This is for the the pros that value their privacy.', TOPLYTICS_DOMAIN ); ?>">
-            <?php _e( 'Private Authorization (Advanced)', TOPLYTICS_DOMAIN ); ?>
+            <?php _e( 'Manual Connect (Advanced)', TOPLYTICS_DOMAIN ); ?>
         </a>
     </h2>
 

--- a/src/resources/views/backend/settings.php
+++ b/src/resources/views/backend/settings.php
@@ -24,7 +24,7 @@ global $toplytics_engine;
     </div>
 
     <h2 class="nav-tab-wrapper">
-        <?php if ( isset( $profile ) && $profile ) : ?>
+        <?php if ( (isset( $profile ) && $profile) || ($use_ga4 && $property_id) ) : ?>
             <?php $nav_tab_active = ( isset( $_GET['tab'] ) ) ? ( ( $_GET['tab'] == 'overview' ) ? 'nav-tab-active' : '' ) : 'nav-tab-active'; ?>
             <a class="nav-tab <?php echo $nav_tab_active; ?>"
                 href="<?php echo admin_url( TOPLYTICS_SUBMENU_PAGE . '?page=' . TOPLYTICS_DOMAIN . '&amp;tab=' . 'overview' ); ?>"
@@ -48,7 +48,7 @@ global $toplytics_engine;
         <?php endif; ?>
     </h2>
 
-    <?php if ( isset( $profile ) && $profile ) : ?>
+    <?php if ( (isset( $profile ) && $profile) || ($use_ga4 && $property_id) ) : ?>
         <?php if ( isset( $_GET['tab'] ) ) : ?>
             <?php if ($_GET['tab'] == 'overview') : ?>
                 <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.tabs.overview' ); ?>
@@ -58,6 +58,8 @@ global $toplytics_engine;
         <?php else : ?>
             <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.tabs.overview' ); ?>
         <?php endif; ?>
+    <?php elseif ($use_ga4) : ?>
+        <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.tabs.gav4' ); ?>
     <?php else : ?>
         <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.tabs.profile' ); ?>
     <?php endif; ?>

--- a/src/resources/views/backend/tabs/gav4.php
+++ b/src/resources/views/backend/tabs/gav4.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This is the settings page and the page where the profile
+ * selection is taking place. The various submit buttons
+ * it has on this page will be conditionally
+ * displayed according to the plguin
+ * settings.
+ * 
+ * (array) $profile - This is the connected profile currently
+ * being used by the Toplytics Widget. We use this in our
+ * template to understand if we are connected and chose
+ * an actual profile or not and display the relevant
+ * information accordingly.
+ * 
+ * (array) $profiles - These are all the profiles available
+ * on the profiles selection screen.
+ * 
+ * (string) $auth - This variable contains the way we have
+ * authenticated for the plugin. (public / private)
+ * 
+ * (string) $lastUpdateTime - the date in the proper ISO format
+ * which also supports translation.
+ * 
+ * (string) $lastUpdateCount - The number of items updated from
+ * analytics on the last update.
+ */
+
+global $toplytics_engine;
+
+?>
+
+<form action="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ); ?>" method="POST">
+    <?php wp_nonce_field( 'toplytics-settings' ); ?>
+
+    <h3><?php _e( 'GA4 Property ID', TOPLYTICS_DOMAIN ); ?></h3>
+    <p><?php _e( 'Enter your GA4 property ID below. You can find this in your Admin > Property Settings from <a href="https://analytics.google.com/analytics/web/" target="_blank"> analytics.google.com</a>.', TOPLYTICS_DOMAIN ); ?></p>
+
+    <ul>
+        <li><label for="property_id"><?php _e( 'Propery ID', TOPLYTICS_DOMAIN ); ?><span> *</span>: </label>
+            <input if="property_id" name="property_id" type="number">
+        </li>
+    </ul>
+
+    <div class="submit">
+        <?php // We show different submit buttons based on whether the user has chosen a profile or not. ?>
+
+        <input type="submit" name="ToplyticsProfileSelect" class="button-primary" value="<?php esc_attr_e( 'Confirm Property', TOPLYTICS_DOMAIN ); ?>" />
+        
+        &nbsp;&nbsp;
+
+        <input type="submit" name="ToplyticsSubmitAccountDisconnect" class="button" value="<?php esc_attr_e( 'Disconnect Google Account', TOPLYTICS_DOMAIN ); ?>" />
+    </div>
+
+</form>

--- a/src/resources/views/backend/tabs/overview.php
+++ b/src/resources/views/backend/tabs/overview.php
@@ -47,7 +47,7 @@ global $toplytics_engine;
                     <?php if ( isset( $auth ) && $auth == 'private' ) : ?>
                     <?php _e( '<span>You are using the <strong>Private</strong> Authorization method. Good choice.</span>', TOPLYTICS_DOMAIN ); ?>
                     <?php else : ?>
-                        <?php _e('<span>You are using the Presslabs public authorization method.</span>', TOPLYTICS_DOMAIN ); ?>
+                        <?php _e('<span>You are using the Presslabs quick connect method.</span>', TOPLYTICS_DOMAIN ); ?>
                     <?php endif; ?>
                 </td>
             </tr>

--- a/src/resources/views/backend/tabs/overview.php
+++ b/src/resources/views/backend/tabs/overview.php
@@ -32,7 +32,7 @@ global $toplytics_engine;
 <form action="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ); ?>" method="POST">
     <?php wp_nonce_field( 'toplytics-settings' ); ?>
 
-    <?php if ( isset( $profile ) && $profile ) : ?>
+    <?php if ( (isset( $profile ) && $profile) || ($use_ga4 && $property_id) ) : ?>
 
         <h3><?php _e( 'User profile info', TOPLYTICS_DOMAIN ); ?></h3>
         <p><?php _e( 'Below is the information regarding your connection and selected profile, as well as quick button controls to change them.', TOPLYTICS_DOMAIN ); ?></p>
@@ -51,12 +51,42 @@ global $toplytics_engine;
                     <?php endif; ?>
                 </td>
             </tr>
+
+            <?php if ($use_ga4) : ?>
+            <tr valign="top">
+                <th scope="row">
+                    <label><?php _e( 'Analytics Version', TOPLYTICS_DOMAIN ); ?></label>
+                </th>
+                <td>
+                    <?php _e( '<span>You are using the <strong>GA4</strong> version of Analytics.</span>', TOPLYTICS_DOMAIN ); ?>
+                </td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">
+                    <label><?php _e( 'Property ID', TOPLYTICS_DOMAIN ); ?></label>
+                </th>
+                <td>
+                    <?php echo $property_id; ?>
+                </td>
+            </tr>
+
+            <?php else : ?>
+            <tr valign="top">
+                <th scope="row">
+                    <label><?php _e( 'Analytics Version', TOPLYTICS_DOMAIN ); ?></label>
+                </th>
+                <td>
+                    <?php _e( '<span>You are using the <strong>Universal Analytics</strong> version of Analytics.</span>', TOPLYTICS_DOMAIN ); ?>
+                </td>
+            </tr>
             <tr valign="top">
                 <th scope="row">
                     <label><?php _e( 'Active Profile', TOPLYTICS_DOMAIN ); ?></label>
                 </th>
                 <td><?php echo $profile['profile_info']; ?></td>
             </tr>
+            <?php endif; ?>
+
             <tr valign="top">
                 <th scope="row">
                     <label><?php _e( 'Last Data Update', TOPLYTICS_DOMAIN ); ?></label>
@@ -70,7 +100,7 @@ global $toplytics_engine;
                 <td><?php echo $lastUpdateCount; ?></td>
             </tr>
         </table>
-    <?php else : ?>
+    <?php /* else : ?>
         <?php // We show the google analytics profiles so the user can chose which one he wants to use. ?>
 
         <h3><?php _e( 'User profile selection', TOPLYTICS_DOMAIN ); ?></h3>
@@ -90,12 +120,12 @@ global $toplytics_engine;
             <?php $type = 'info'; ?>
             <?php $message = __( "Oh NO! There has been an error or there are no profiles to select for this account. You might want to add some or disconnect this Google Account using the button below.", TOPLYTICS_DOMAIN ); ?>
             <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.partials.inlineNotification' ); ?>
-        <?php endif; ?>
+        <?php endif; */ ?>
     <?php endif; ?>
 
     <div class="submit">
         <?php // We show different submit buttons based on whether the user has chosen a profile or not. ?>
-        <?php if ( isset( $profile ) && $profile ) : ?>
+        <?php if ( (isset( $profile ) && $profile) || ($use_ga4 && $property_id) ) : ?>
             <a href="<?php echo admin_url('widgets.php'); ?>" class="button-primary"><?php _e( 'Widgets Management', TOPLYTICS_DOMAIN ); ?></a>&nbsp;&nbsp;
             <input type="submit" name="ToplyticsSubmitForceUpdate" class="button" value="<?php esc_attr_e( 'Update Top', TOPLYTICS_DOMAIN ); ?>" />&nbsp;&nbsp;
             <input type="submit" name="ToplyticsSubmitProfileSwitch" class="button" value="<?php esc_attr_e( 'Switch Analytics Profile', TOPLYTICS_DOMAIN ); ?>" />

--- a/src/resources/views/backend/tabs/privateConnect.php
+++ b/src/resources/views/backend/tabs/privateConnect.php
@@ -10,8 +10,8 @@
  */
 ?>
 
-<h2><?php _e( 'Private Authorization', TOPLYTICS_DOMAIN ); ?></h2>
-<p><?php _e( 'The private authorization is the recommended way for connecting to your Google account, even if it is a bit more difficult and cumbersome. <br />It offers you complete control over the connection by using your very own API keys and application for granting access.', TOPLYTICS_DOMAIN ); ?></p>
+<h2><?php _e( 'Manual Connect', TOPLYTICS_DOMAIN ); ?></h2>
+<p><?php _e( 'The manual connect is the recommended way for connecting to your Google account, even if it is a bit more difficult and cumbersome. <br />It offers you complete control over the connection by using your very own API keys and application for granting access.', TOPLYTICS_DOMAIN ); ?></p>
 
 <form action="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ); ?>" method="POST">
 

--- a/src/resources/views/backend/tabs/profile.php
+++ b/src/resources/views/backend/tabs/profile.php
@@ -34,7 +34,7 @@ global $toplytics_engine;
 
     <?php // We show the google analytics profiles so the user can chose which one he wants to use. ?>
 
-    <h3><?php _e( 'User profile selection', TOPLYTICS_DOMAIN ); ?></h3>
+    <h3><?php _e( 'User profile selection for Universal Analytics', TOPLYTICS_DOMAIN ); ?></h3>
     <p><?php _e( 'Select from the list of profiles the one you wish to use for this site.', TOPLYTICS_DOMAIN ); ?></p>
 
     <?php if ( isset( $profiles ) && $profiles ) : ?>
@@ -59,6 +59,10 @@ global $toplytics_engine;
         <?php if ( isset( $profiles ) && $profiles ) : ?>
             <input type="submit" name="ToplyticsProfileSelect" class="button-primary" value="<?php esc_attr_e( 'Select Profile', TOPLYTICS_DOMAIN ); ?>" />
         <?php endif; ?>
+        
+        &nbsp;&nbsp;
+
+        <input type="submit" name="ToplyticsUseGA4" class="button" value="<?php esc_attr_e( 'Click here to use GA4 instead of UA!', TOPLYTICS_DOMAIN ); ?>" />
 
         &nbsp;&nbsp;
 

--- a/src/resources/views/backend/tabs/publicConnect.php
+++ b/src/resources/views/backend/tabs/publicConnect.php
@@ -12,7 +12,7 @@ global $toplytics_engine;
 
 ?>
 
-<h3><?php _e( 'Public Authorization', TOPLYTICS_DOMAIN ); ?></h3>
+<h3><?php _e( 'Quick Connect', TOPLYTICS_DOMAIN ); ?></h3>
 <p><?php _e( 'This authorization method is using the Presslabs public API key to authenticate you to the Google Analytics API.<br />If you are concerned about privacy or are having any API related errors using this method, please use the private method.', TOPLYTICS_DOMAIN ); ?></p>
 
 <form action="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ); ?>" method="POST">
@@ -24,5 +24,11 @@ global $toplytics_engine;
     <?php include $toplytics_engine->backend->getWindow()->getView( 'backend.partials.inlineNotification' ); ?>
 
     <input type="submit" title="Log in with your Google Account" name="ToplyticsSubmitPublicAuthorization" class="button-primary" style="margin: 20px;" value="<?php esc_attr_e( 'Log in with your Google Account via Presslabs.org', TOPLYTICS_DOMAIN ); ?>" />
+
+    <?php
+        // TODO: Use Official Google login buton and JS method. 
+        // https://developers.google.com/identity/gsi/web/guides/display-button#html_2
+        // Maybe use button generator: https://developers.google.com/identity/gsi/web/tools/configurator
+    ?>
 
 </form>

--- a/src/toplytics.php
+++ b/src/toplytics.php
@@ -14,7 +14,7 @@ use Toplytics\Deactivator;
  * Plugin Name:       Toplytics - Popular Posts Widget
  * Plugin URI:        https://www.presslabs.org/toplytics/
  * Description:       Display top posts in a widget without putting any pressure on your host and database. This plugin helps you achieve this using the Google Analytics API to get the data from there so your server will stay clear of the preasure of monitoring and counting every single page view to display top posts.
- * Version:           4.0.10
+ * Version:           4.1
  * Author:            Presslabs
  * Author URI:        https://www.presslabs.com/
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if (! defined('WPINC')) {
 /**
  * Plugin default settings
  */
-define('TOPLYTICS_VERSION', '4.0.10');
+define('TOPLYTICS_VERSION', '4.1');
 define('TOPLYTICS_APP_NAME', 'Toplytics - Popular Posts Widget');
 define('TOPLYTICS_DOMAIN', 'toplytics');
 define('TOPLYTICS_ENTRY', 'toplytics.php');
@@ -54,8 +54,8 @@ define('TOPLYTICS_MAX_API_ERRORS_COUNT', 20);
  * already performed to the end user. This version needs to be the same with the Toplytics
  * version for the message to appear. We don't want this to show up for minor hotfixes.
  */
-define('TOPLYTICS_UPDATE_NOTICE_VERSION', '4.0.8');
-define('TOPLYTICS_UPDATE_NOTICE_MESSAGE', 'Thank you for updating to Toplytics v4.0.8. This is a minor release primarily containing bug fixes. Read our docs and FAQ here: https://www.presslabs.com/code/toplytics/how-to-use-toplytics/ Read the full changelog here: https://wordpress.org/plugins/toplytics/#developers');
+define('TOPLYTICS_UPDATE_NOTICE_VERSION', '4.1');
+define('TOPLYTICS_UPDATE_NOTICE_MESSAGE', 'Toplytics has been updated to version 4.1 which adds support for Google Analytics 4. Please make sure to re-authenticate your Google Analytics account in order to continue using the plugin with GA4.');
 
 /**
  * We load the composer dependencies at this stage and the

--- a/src/toplytics.php
+++ b/src/toplytics.php
@@ -31,7 +31,8 @@ if (! defined('WPINC')) {
 /**
  * Plugin default settings
  */
-define('TOPLYTICS_VERSION', '4.1');
+define('TOPLYTICS_VERSION', '4.1.0');
+define('TOPLYTICS_DB_VERSION', '1');
 define('TOPLYTICS_APP_NAME', 'Toplytics - Popular Posts Widget');
 define('TOPLYTICS_DOMAIN', 'toplytics');
 define('TOPLYTICS_ENTRY', 'toplytics.php');

--- a/src/toplytics.php
+++ b/src/toplytics.php
@@ -32,7 +32,6 @@ if (! defined('WPINC')) {
  * Plugin default settings
  */
 define('TOPLYTICS_VERSION', '4.1.0');
-define('TOPLYTICS_DB_VERSION', '1');
 define('TOPLYTICS_APP_NAME', 'Toplytics - Popular Posts Widget');
 define('TOPLYTICS_DOMAIN', 'toplytics');
 define('TOPLYTICS_ENTRY', 'toplytics.php');


### PR DESCRIPTION
This PR adds support for Google Analytics v4, allowing users to display the most visited posts on their websites using data from the latest version of Google Analytics.

Thanks to @marco-s, Toplytics is adding support for additional filters and better range management via options.