### PR TITLE
Re-add getting result ranges & setting from WP options

### DIFF
--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1231,12 +1231,13 @@ class Backend
         }
 
         // TODO: Make these settings configurable.
-        $results_ranges = [
-            'month' => date_i18n('Y-m-d', strtotime('-29 days')),
-            'week'  => date_i18n('Y-m-d', strtotime('-6 days')),
-            // 'today' => date_i18n('Y-m-d', strtotime('today')),
-            // 'realtime' => 0,
-        ];
+        // Fetch results ranges from option. Create the option, if it does not exist.
+        $results_ranges = get_option( 'toplytics_results_ranges', false );
+        if ( ! $results_ranges ) {
+            Activator::addDefaultOptions();
+            // Fetch the option, once again; it is now initialized.
+            $results_ranges = get_option( 'toplytics_results_ranges' );
+        }
 
         $result = [];
 


### PR DESCRIPTION
I need this to get pulled in via options to allow for adding in an options filter hook. Plus the result_ranges should not get hard coded here and get set up via the "default options".