### PR TITLE
fix infinite recursion which causes memory consumption

### DIFF
--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1084,7 +1084,7 @@ class Backend
             }
         }
 
-        if ( $num_stats == 0 ) {
+        if ( $num_stats == 0 && ! $extended_fetch ) {
             // Do another fetch, requesting a higher number of results.
             $num_stats = $this->updateAnalyticsDataResults( true );
         }


### PR DESCRIPTION
I have identified a memory exhaustion error in the logs of a website and have initiated an investigation. After implementing additional debugging code, I have collected the following information:

```php
[11-Jun-2026 16:47:57 UTC] Memory exceeded 400MB at hook: pre_wp_load_alloptions
[11-Jun-2026 16:47:57 UTC] {closure}
[11-Jun-2026 16:47:57 UTC] WP_Hook->do_all_hook
[11-Jun-2026 16:47:57 UTC] _wp_call_all_hook
[11-Jun-2026 16:47:57 UTC] apply_filters
[11-Jun-2026 16:47:57 UTC] wp_load_alloptions
[11-Jun-2026 16:47:57 UTC] get_option
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->getAnalyticsData
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:47:57 UTC] Toplytics\Backend->updateAnalyticsDataResults
[11-Jun-2026 16:48:02 UTC] PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 262144 bytes) in /app/web/wp-includes/class-wp-hook.php on line 388
```

At lines 1087-1090, when $num_stats == 0 and $extended_fetch is already true, the function still calls itself recursively with true again, resulting in infinite recursion. 

The fix introduces && ! $extended_fetch to the guard condition — since the extended fetch is the final attempt, if it also returns 0 results, the function returns 0 instead of recursing further.