### PR TITLE
Catch network errors during Google token refresh

### DIFF
--- a/src/components/Backend.php
+++ b/src/components/Backend.php
@@ -1562,8 +1562,20 @@ class Backend
 
         if ($this->client->isAccessTokenExpired()) {
             if (isset($googleToken['refresh_token']) && $refresh_token = $googleToken['refresh_token']) {
-                $this->client->refreshToken($refresh_token);
-                update_option('toplytics_google_token', $this->client->getAccessToken());
+                // Wrap the refresh in try/catch so transient network failures
+                // (DNS, timeouts, offline laptops) don't fatal the whole admin.
+                try {
+                    $this->client->refreshToken($refresh_token);
+                    update_option('toplytics_google_token', $this->client->getAccessToken());
+                } catch (\Throwable $e) {
+                    $this->window->notifyAdmins('warning', sprintf(
+                        /* translators: %s: error message returned by Google/Guzzle */
+                        __('Toplytics could not refresh the Google Analytics access token: %s', TOPLYTICS_DOMAIN),
+                        $e->getMessage()
+                    ));
+
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
Catch network errors during Google token refresh.

Previously, a transient failure (DNS, timeout, offline) thrown by Google\Client::refreshToken() in Backend::serviceConnect() and caused a fatal error in wp-admin / wp-login.php, since Backend is instantiated on
every admin request via Engine::defineAdminHooks().

Wrap the refresh in try/catch (mirroring the sibling fetchAccessToken flow), surface a non-fatal admin notice, and return false so callers fall back to the already-handled "no service" path.